### PR TITLE
feat: add auto-author-assign workflow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,14 @@
+name: Auto Assign PR Author
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2


### PR DESCRIPTION
# Description

PR should always be assigned to their author, this PR adds a workflow to do exactly that.

## Additions and Changes

### New feature (non-breaking change which adds functionality)

- Add an `auto-author-assign` workflow to automatically assign the PR to its author

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
